### PR TITLE
Added homepage to the package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "A design-oriented theme that doesn't hurt your brain.",
     "version": "1.0.0",
     "author": "Mr. Dollywaggit",
+    "homepage": "https://github.com/MrDollywaggit/brackets-encode",
     "license": "MIT",
     "engines": {
         "brackets": ">=0.42.0"


### PR DESCRIPTION
This will add the "more info" link at the bottom of your theme description in Brackets. This will redirect people to your repository page to preview your theme before installation.

It also gives visitors the option of seeing your repository instead of the homepage. Some people have many repositories so this step will save your potential visitors a bit of time.
